### PR TITLE
Simplify serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
   - `errors` > `player_errors`
 - Attempting to delete playing playlist entry now returns 404 instead of 403.
 - Pagination information (`current` and `last`) for views that use a paginator are now gathered in the `pagination` key in the response.
+- Song serialization no longer contains the `link_type_name` key (work link long name), the info has to be deduced from `link_type`.
+- In the route `/playlist/entries`, the key to designate a song has changed: `song` > `song_id`.
 
 ## 1.1.0 - 2018-01-25
 

--- a/dakara_server/library/migrations/0005_auto_20180509_1916.py
+++ b/dakara_server/library/migrations/0005_auto_20180509_1916.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('library', '0004_auto_20171229_1920'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='songworklink',
+            name='link_type',
+            field=models.CharField(
+                max_length=2,
+                choices=[
+                    ('OP', 'Opening'),
+                    ('ED', 'Ending'),
+                    ('IN', 'Insert song'),
+                    ('IS', 'Image song')
+                ]
+            ),
+        ),
+    ]

--- a/dakara_server/library/models.py
+++ b/dakara_server/library/models.py
@@ -85,7 +85,7 @@ class SongWorkLink(models.Model):
         (OPENING, "Opening"),
         (ENDING, "Ending"),
         (INSERT, "Insert song"),
-        (IMAGE, "Image somg"),
+        (IMAGE, "Image song"),
     )
 
     song = models.ForeignKey(Song, on_delete=models.CASCADE)

--- a/dakara_server/library/permissions.py
+++ b/dakara_server/library/permissions.py
@@ -1,6 +1,10 @@
 from rest_framework import permissions
+from django.contrib.auth import get_user_model
 
 from users.permissions import BasePermissionCustom
+
+
+UserModel = get_user_model()
 
 
 class IsLibraryManagerOrReadOnly(BasePermissionCustom):
@@ -19,4 +23,4 @@ class IsLibraryManagerOrReadOnly(BasePermissionCustom):
             return True
 
         # for modification
-        return request.user.has_library_permission_level('m')
+        return request.user.has_library_permission_level(UserModel.MANAGER)

--- a/dakara_server/library/serializers.py
+++ b/dakara_server/library/serializers.py
@@ -15,7 +15,7 @@ class SecondsDurationField(serializers.DurationField):
         return int(round(value.total_seconds()))
 
 
-class ArtistNoCountSerializer(serializers.ModelSerializer):
+class ArtistSerializer(serializers.ModelSerializer):
     """Artist serializer
 
     Used in song representation.
@@ -28,7 +28,7 @@ class ArtistNoCountSerializer(serializers.ModelSerializer):
         )
 
 
-class ArtistSerializer(serializers.ModelSerializer):
+class ArtistWithCountSerializer(serializers.ModelSerializer):
     """Artist serializer
 
     Including a song count.
@@ -134,12 +134,10 @@ class SongSerializer(serializers.ModelSerializer):
     """Song serializer
     """
     duration = SecondsDurationField()
-    artists = ArtistNoCountSerializer(many=True, read_only=True)
+    artists = ArtistSerializer(many=True, read_only=True)
     tags = SongTagSerializer(many=True, read_only=True)
-    works = SongWorkLinkSerializer(
-        many=True,
-        read_only=True,
-        source='songworklink_set')
+    works = SongWorkLinkSerializer(many=True, read_only=True,
+                                   source='songworklink_set')
     lyrics = serializers.SerializerMethodField()
 
     class Meta:
@@ -186,7 +184,7 @@ class SongForPlayerSerializer(serializers.ModelSerializer):
 
     To be used by the player.
     """
-    artists = ArtistNoCountSerializer(many=True, read_only=True)
+    artists = ArtistSerializer(many=True, read_only=True)
     works = SongWorkLinkSerializer(
         many=True,
         read_only=True,

--- a/dakara_server/library/serializers.py
+++ b/dakara_server/library/serializers.py
@@ -106,31 +106,15 @@ class SongWorkLinkSerializer(serializers.ModelSerializer):
     """Serialization of the use of a song in a work
     """
     work = WorkNoCountSerializer(many=False, read_only=True)
-    link_type_name = serializers.SerializerMethodField()
 
     class Meta:
         model = SongWorkLink
         fields = (
             'work',
             'link_type',
-            'link_type_name',
             'link_type_number',
             'episodes',
         )
-
-    @staticmethod
-    def get_link_type_name(song_work_link):
-        """Get the explicit name of a work link
-        """
-        link_type_name = [
-            choice[1]
-            for choice in SongWorkLink.LINK_TYPE_CHOICES
-            if choice[0] == song_work_link.link_type
-        ]
-        if len(link_type_name) < 1:
-            return song_work_link.link_type
-
-        return link_type_name[0]
 
 
 class SongTagSerializer(serializers.ModelSerializer):
@@ -178,23 +162,21 @@ class SongSerializer(serializers.ModelSerializer):
         )
 
     @staticmethod
-    def get_lyrics(song):
+    def get_lyrics(song, max_lines=5):
         """Get an extract of the lyrics
 
-        Give at most `MAX_LINES` lines of lyrics and tell if more lines remain.
+        Give at most `max_lines` lines of lyrics and tell if more lines remain.
         """
-        MAX_LINES = 5
-
         if not song.lyrics:
             return None
 
         lyrics_list = song.lyrics.splitlines()
 
-        if len(lyrics_list) <= MAX_LINES:
+        if len(lyrics_list) <= max_lines:
             return {'text': song.lyrics}
 
         return {
-            'text': '\n'.join(lyrics_list[:MAX_LINES]),
+            'text': '\n'.join(lyrics_list[:max_lines]),
             'truncated': True
         }
 

--- a/dakara_server/library/tests_song.py
+++ b/dakara_server/library/tests_song.py
@@ -1,7 +1,11 @@
 from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
 from rest_framework import status
 
 from .base_test import BaseAPITestCase
+
+
+UserModel = get_user_model()
 
 
 class SongListViewAPIViewTestCase(BaseAPITestCase):
@@ -12,7 +16,8 @@ class SongListViewAPIViewTestCase(BaseAPITestCase):
         self.user = self.create_user("TestUser")
 
         # create a manager
-        self.manager = self.create_user("TestManager", library_level='m')
+        self.manager = self.create_user("TestManager",
+                                        library_level=UserModel.MANAGER)
 
         # create test data
         self.create_library_test_data()

--- a/dakara_server/library/tests_song_tag.py
+++ b/dakara_server/library/tests_song_tag.py
@@ -1,8 +1,12 @@
 from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
 from rest_framework import status
 
 from .base_test import BaseAPITestCase
 from .models import SongTag
+
+
+UserModel = get_user_model()
 
 
 class SongTagListViewListAPIViewTestCase(BaseAPITestCase):
@@ -43,7 +47,7 @@ class SongTagViewUpdateAPIViewTestCase(BaseAPITestCase):
     def setUp(self):
         # create a user without any rights
         self.manager = self.create_user("TestUserManager",
-                                        library_level='m')
+                                        library_level=UserModel.MANAGER)
 
         self.user = self.create_user("TestUser")
 

--- a/dakara_server/library/views.py
+++ b/dakara_server/library/views.py
@@ -1,5 +1,6 @@
 from django.db.models.functions import Lower
 from django.db.models import Q
+from django.contrib.auth import get_user_model
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.generics import (
@@ -9,10 +10,13 @@ from rest_framework.generics import (
     ListAPIView,
 )
 
-from . import models
-from . import serializers
-from .query_language import QueryLanguageParser
-from .permissions import IsLibraryManagerOrReadOnly
+from library import models
+from library import serializers
+from library.query_language import QueryLanguageParser
+from library.permissions import IsLibraryManagerOrReadOnly
+
+
+UserModel = get_user_model()
 
 
 class LibraryPagination(PageNumberPagination):
@@ -70,7 +74,8 @@ class SongListView(ListCreateAPIViewWithQueryParsed):
 
         # hide all songs with disabled tags for non-managers or non-superusers
         user = self.request.user
-        if not (user.is_superuser or user.has_library_permission_level('m')):
+        if not (user.is_superuser or
+                user.has_library_permission_level(UserModel.MANAGER)):
             query_set = query_set.exclude(tags__disabled=True)
 
         # if 'query' is in the query string then perform search otherwise

--- a/dakara_server/library/views.py
+++ b/dakara_server/library/views.py
@@ -169,7 +169,7 @@ class ArtistListView(ListCreateAPIViewWithQueryParsed):
     """
     permission_classes = (IsLibraryManagerOrReadOnly,)
 
-    serializer_class = serializers.ArtistSerializer
+    serializer_class = serializers.ArtistWithCountSerializer
     pagination_class = LibraryPagination
 
     def get_queryset(self):

--- a/dakara_server/playlist/base_test.py
+++ b/dakara_server/playlist/base_test.py
@@ -77,14 +77,16 @@ class BaseAPITestCase(APITestCase):
         self.user = self.create_user("TestUser")
 
         # create a playlist user
-        self.p_user = self.create_user("TestPlaylistUser", playlist_level="u")
+        self.p_user = self.create_user("TestPlaylistUser",
+                                       playlist_level=UserModel.USER)
 
         # create a playlist manager
-        self.manager = self.create_user(
-            "testPlaylistManager", playlist_level="m")
+        self.manager = self.create_user("testPlaylistManager",
+                                        playlist_level=UserModel.MANAGER)
 
         # create a player
-        self.player = self.create_user("testPlayer", playlist_level="p")
+        self.player = self.create_user("testPlayer",
+                                       playlist_level=UserModel.PLAYER)
 
         # Create tags
         self.tag1 = SongTag(name='TAG1')

--- a/dakara_server/playlist/management/commands/createplayer.py
+++ b/dakara_server/playlist/management/commands/createplayer.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 from django.db.utils import IntegrityError
 
+
 UserModel = get_user_model()
 
 
@@ -30,6 +31,6 @@ class Command(BaseCommand):
             self.stdout.write("Account '{}' already exists".format(username))
             return
 
-        player.playlist_permission_level = 'p'
+        player.playlist_permission_level = UserModel.PLAYER
         player.save()
         self.stdout.write("Player created with name '{}'!".format(username))

--- a/dakara_server/playlist/permissions.py
+++ b/dakara_server/playlist/permissions.py
@@ -30,7 +30,7 @@ class IsPlaylistManagerOrOwnerOrReadOnly(BasePermissionCustom):
             return True
 
         # if the object belongs to the user
-        return obj.owner_id == request.user.id
+        return obj.owner == request.user
 
 
 class IsPlaylistUserOrReadOnly(BasePermissionCustom):
@@ -106,7 +106,7 @@ class IsPlaylistManagerOrPlayingEntryOwnerOrReadOnly(BasePermissionCustom):
         if not playlist_entry:
             return False
 
-        return playlist_entry.owner_id == request.user.id
+        return playlist_entry.owner == request.user
 
 
 class IsPlaylistAndLibraryManagerOrSongCanBeAdded(BasePermissionCustom):

--- a/dakara_server/playlist/permissions.py
+++ b/dakara_server/playlist/permissions.py
@@ -30,7 +30,7 @@ class IsPlaylistManagerOrOwnerOrReadOnly(BasePermissionCustom):
             return True
 
         # if the object belongs to the user
-        return obj.owner == request.user
+        return obj.owner_id == request.user.id
 
 
 class IsPlaylistUserOrReadOnly(BasePermissionCustom):
@@ -106,7 +106,7 @@ class IsPlaylistManagerOrPlayingEntryOwnerOrReadOnly(BasePermissionCustom):
         if not playlist_entry:
             return False
 
-        return playlist_entry.owner == request.user
+        return playlist_entry.owner_id == request.user.id
 
 
 class IsPlaylistAndLibraryManagerOrSongCanBeAdded(BasePermissionCustom):
@@ -126,7 +126,7 @@ class IsPlaylistAndLibraryManagerOrSongCanBeAdded(BasePermissionCustom):
             return True
 
         # get song
-        song_id = request.data.get('song')
+        song_id = request.data.get('song_id')
         if not song_id:
             return True
 

--- a/dakara_server/playlist/permissions.py
+++ b/dakara_server/playlist/permissions.py
@@ -1,9 +1,13 @@
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import permissions
+from django.contrib.auth import get_user_model
 
 from users.permissions import BasePermissionCustom
 from library.models import Song
 from .models import PlaylistEntry, Player, KaraStatus
+
+
+UserModel = get_user_model()
 
 
 class IsPlaylistManagerOrOwnerOrReadOnly(BasePermissionCustom):
@@ -26,7 +30,7 @@ class IsPlaylistManagerOrOwnerOrReadOnly(BasePermissionCustom):
             return True
 
         # for manager
-        if request.user.has_playlist_permission_level('m'):
+        if request.user.has_playlist_permission_level(UserModel.MANAGER):
             return True
 
         # if the object belongs to the user
@@ -49,7 +53,7 @@ class IsPlaylistUserOrReadOnly(BasePermissionCustom):
             return True
 
         # for modification
-        return request.user.has_playlist_permission_level('u')
+        return request.user.has_playlist_permission_level(UserModel.USER)
 
 
 class IsPlaylistManagerOrReadOnly(BasePermissionCustom):
@@ -68,7 +72,7 @@ class IsPlaylistManagerOrReadOnly(BasePermissionCustom):
             return True
 
         # for modification
-        return request.user.has_playlist_permission_level('m')
+        return request.user.has_playlist_permission_level(UserModel.MANAGER)
 
 
 class IsPlaylistManagerOrPlayingEntryOwnerOrReadOnly(BasePermissionCustom):
@@ -92,7 +96,7 @@ class IsPlaylistManagerOrPlayingEntryOwnerOrReadOnly(BasePermissionCustom):
             return True
 
         # for manager
-        if request.user.has_playlist_permission_level('m'):
+        if request.user.has_playlist_permission_level(UserModel.MANAGER):
             return True
 
         # if the currently playing song belongs to the user
@@ -121,8 +125,8 @@ class IsPlaylistAndLibraryManagerOrSongCanBeAdded(BasePermissionCustom):
 
     def has_permission_custom(self, request, view):
         # for manager of playlist and library
-        if request.user.has_playlist_permission_level('m') and \
-                request.user.has_library_permission_level('m'):
+        if request.user.has_playlist_permission_level(UserModel.MANAGER) and \
+                request.user.has_library_permission_level(UserModel.MANAGER):
             return True
 
         # get song
@@ -150,7 +154,7 @@ class IsPlayer(BasePermissionCustom):
     """
 
     def has_permission_custom(self, request, view):
-        return request.user.has_playlist_permission_level('p')
+        return request.user.has_playlist_permission_level(UserModel.PLAYER)
 
 
 class KaraStatusIsNotStoppedOrReadOnly(permissions.BasePermission):

--- a/dakara_server/playlist/serializers.py
+++ b/dakara_server/playlist/serializers.py
@@ -1,105 +1,96 @@
 from rest_framework import serializers
 
 from playlist.models import PlaylistEntry, KaraStatus
+from library.models import Song
 from library.serializers import (
     SongSerializer,
-    SongForPlayerSerializer,
     SecondsDurationField,
 )
 from users.serializers import (
     UserForPublicSerializer,
 )
+from playlist import serializers_device as device # noqa F401
+from playlist.serializers_device import PlayerCommandSerializer
 
 
 class PlaylistEntrySerializer(serializers.ModelSerializer):
-    """Song serializer in playlist
+    """Playlist entry serializer
     """
-    owner = serializers.PrimaryKeyRelatedField(
-        read_only=True,
-        default=serializers.CreateOnlyDefault(
-            serializers.CurrentUserDefault()
-        )
+    # get related owner field
+    # auto-set related owner field
+    owner = UserForPublicSerializer(read_only=True,
+                                    default=serializers.CurrentUserDefault())
+
+    # get related song field
+    song = SongSerializer(many=False, read_only=True)
+
+    # set related song field
+    song_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source='song',
+        queryset=Song.objects.all()
     )
 
     class Meta:
         model = PlaylistEntry
         fields = (
             'id',
-            'song',
             'date_created',
             'owner',
+            'song',
+            'song_id',
+        )
+        read_only_fields = (
+            'date_created',
         )
 
 
-class PlaylistEntryReadSerializer(serializers.ModelSerializer):
-    """Song serializer in playlist
-    """
-    song = SongSerializer(many=False, read_only=True)
-    owner = UserForPublicSerializer(read_only=True)
+class PlaylistEntryWithDatePlaySerializer(PlaylistEntrySerializer):
+    """Playlist entry serializer
 
+    Reserved for song that will be played.
+    """
     # date of play in the future, added manually to the PlaylistEntry object
     date_play = serializers.DateTimeField(read_only=True)
 
-    class Meta:
-        model = PlaylistEntry
+    class Meta(PlaylistEntrySerializer.Meta):
         fields = (
             'id',
-            'song',
             'date_created',
-            'owner',
             'date_play',
+            'owner',
+            'song',
         )
 
 
-class PlaylistEntriesReadSerializer(serializers.Serializer):
+class PlaylistPlayedEntryWithDatePlayedSerializer(PlaylistEntrySerializer):
+    """Playlist entry serializer
+
+    Reserved for song that were played.
+    """
+
+    class Meta(PlaylistEntrySerializer.Meta):
+        fields = (
+            'id',
+            'date_created',
+            'date_played',
+            'owner',
+            'song',
+        )
+        read_only_fields = (
+            'date_created',
+            'date_played',
+        )
+
+
+class PlaylistEntriesWithDateEndSerializer(serializers.Serializer):
     """Playlist entries with playlist end date
     """
-    results = PlaylistEntryReadSerializer(many=True, read_only=True)
+    results = PlaylistEntryWithDatePlaySerializer(many=True, read_only=True)
     date_end = serializers.DateTimeField(read_only=True)
 
 
-class PlaylistPlayedEntryReadSerializer(serializers.ModelSerializer):
-    """Song serializer in playlist
-    """
-    song = SongSerializer(many=False, read_only=True)
-    owner = UserForPublicSerializer(read_only=True)
-
-    class Meta:
-        model = PlaylistEntry
-        fields = (
-            'id',
-            'song',
-            'date_created',
-            'owner',
-            'date_played'
-        )
-
-
-class PlaylistEntryForPlayerSerializer(serializers.ModelSerializer):
-    """Song serializer in playlist
-    """
-    song = SongForPlayerSerializer(many=False, read_only=True)
-    owner = UserForPublicSerializer(read_only=True)
-
-    class Meta:
-        model = PlaylistEntry
-        fields = (
-            'id',
-            'song',
-            'date_created',
-            'owner',
-        )
-
-
-class PlayerSerializer(serializers.Serializer):
-    """Player serializer
-    """
-    playlist_entry_id = serializers.IntegerField(allow_null=True)
-    timing = SecondsDurationField(allow_null=True)
-    paused = serializers.BooleanField(default=False)
-
-
-class PlayerDetailsSerializer(serializers.Serializer):
+class PlayerStatusSerializer(serializers.Serializer):
     """Player serializer with nested playlist_entry and song details
     """
     playlist_entry = serializers.SerializerMethodField()
@@ -113,7 +104,7 @@ class PlayerDetailsSerializer(serializers.Serializer):
         """
         if player.playlist_entry_id is not None:
             entry = PlaylistEntry.objects.get(id=player.playlist_entry_id)
-            return PlaylistPlayedEntryReadSerializer(
+            return PlaylistPlayedEntryWithDatePlayedSerializer(
                 entry,
                 context=self.context
             ).data
@@ -121,21 +112,7 @@ class PlayerDetailsSerializer(serializers.Serializer):
         return None
 
 
-class PlayerCommandSerializer(serializers.Serializer):
-    """Player command serializer
-    """
-    pause = serializers.BooleanField(default=False)
-    skip = serializers.BooleanField(default=False)
-
-
 class PlayerErrorSerializer(serializers.Serializer):
-    """Player errors
-    """
-    playlist_entry = serializers.IntegerField()
-    error_message = serializers.CharField(max_length=255)
-
-
-class PlayerErrorsPoolSerializer(serializers.Serializer):
     """Player errors sent to the client
     """
     id = serializers.IntegerField()
@@ -157,7 +134,7 @@ class KaraStatusSerializer(serializers.ModelSerializer):
 class DigestSerializer(serializers.Serializer):
     """Combine player info and kara status
     """
-    player_status = PlayerDetailsSerializer()
+    player_status = PlayerStatusSerializer()
     player_manage = PlayerCommandSerializer()
-    player_errors = PlayerErrorsPoolSerializer(many=True)
+    player_errors = PlayerErrorSerializer(many=True)
     kara_status = KaraStatusSerializer()

--- a/dakara_server/playlist/serializers.py
+++ b/dakara_server/playlist/serializers.py
@@ -7,7 +7,7 @@ from library.serializers import (
     SecondsDurationField,
 )
 from users.serializers import (
-    UserDisplaySerializer,
+    UserForPublicSerializer,
 )
 
 
@@ -35,7 +35,9 @@ class PlaylistEntryReadSerializer(serializers.ModelSerializer):
     """Song serializer in playlist
     """
     song = SongSerializer(many=False, read_only=True)
-    owner = UserDisplaySerializer(read_only=True)
+    owner = UserForPublicSerializer(read_only=True)
+
+    # date of play in the future, added manually to the PlaylistEntry object
     date_play = serializers.DateTimeField(read_only=True)
 
     class Meta:
@@ -60,7 +62,7 @@ class PlaylistPlayedEntryReadSerializer(serializers.ModelSerializer):
     """Song serializer in playlist
     """
     song = SongSerializer(many=False, read_only=True)
-    owner = UserDisplaySerializer(read_only=True)
+    owner = UserForPublicSerializer(read_only=True)
 
     class Meta:
         model = PlaylistEntry
@@ -77,7 +79,7 @@ class PlaylistEntryForPlayerSerializer(serializers.ModelSerializer):
     """Song serializer in playlist
     """
     song = SongForPlayerSerializer(many=False, read_only=True)
-    owner = UserDisplaySerializer(read_only=True)
+    owner = UserForPublicSerializer(read_only=True)
 
     class Meta:
         model = PlaylistEntry

--- a/dakara_server/playlist/serializers_device.py
+++ b/dakara_server/playlist/serializers_device.py
@@ -1,0 +1,51 @@
+from rest_framework import serializers
+
+from playlist.models import PlaylistEntry
+from library.serializers import (
+    SongForPlayerSerializer,
+    SecondsDurationField,
+)
+from users.serializers import (
+    UserForPublicSerializer,
+)
+
+
+class PlaylistEntrySerializer(serializers.ModelSerializer):
+    """Song serializer in playlist
+    """
+    song = SongForPlayerSerializer(many=False, read_only=True)
+    owner = UserForPublicSerializer(read_only=True)
+
+    class Meta:
+        model = PlaylistEntry
+        fields = (
+            'id',
+            'song',
+            'date_created',
+            'owner',
+        )
+        read_only_fields = (
+            'date_created',
+        )
+
+
+class PlayerSerializer(serializers.Serializer):
+    """Player serializer
+    """
+    playlist_entry_id = serializers.IntegerField(allow_null=True)
+    timing = SecondsDurationField(allow_null=True)
+    paused = serializers.BooleanField(default=False)
+
+
+class PlayerCommandSerializer(serializers.Serializer):
+    """Player command serializer
+    """
+    pause = serializers.BooleanField(default=False)
+    skip = serializers.BooleanField(default=False)
+
+
+class PlayerErrorSerializer(serializers.Serializer):
+    """Player errors
+    """
+    playlist_entry = serializers.IntegerField()
+    error_message = serializers.CharField(max_length=255)

--- a/dakara_server/playlist/tests_playlist_entry.py
+++ b/dakara_server/playlist/tests_playlist_entry.py
@@ -110,7 +110,7 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.assertEqual(PlaylistEntry.objects.count(), 4)
 
         # Post new playlist entry
-        response = self.client.post(self.url, {"song": self.song1.id})
+        response = self.client.post(self.url, {"song_id": self.song1.id})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Check playlist entry has been created in database
@@ -131,7 +131,7 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.authenticate(self.manager)
 
         # Post new playlist entry
-        response = self.client.post(self.url, {"song": self.song1.id})
+        response = self.client.post(self.url, {"song_id": self.song1.id})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch('playlist.views.settings')
@@ -150,7 +150,7 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.assertEqual(PlaylistEntry.objects.count(), 4)
 
         # Post new playlist entry
-        response = self.client.post(self.url, {"song": self.song1.id})
+        response = self.client.post(self.url, {"song_id": self.song1.id})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_post_create_user_forbidden(self):
@@ -160,7 +160,7 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.authenticate(self.user)
 
         # Attempt to post new playlist entry
-        response = self.client.post(self.url, {"song": self.song1.id})
+        response = self.client.post(self.url, {"song_id": self.song1.id})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get_playlist_entries_list_playing_entry(self):
@@ -181,8 +181,9 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.check_playlist_entry_json(response.data['results'][0], self.pe2)
 
     def test_post_create_playlist_entry_disabled_tag(self):
-        """Test to verify playlist entry creation is forbidden for a song with a
-        disabled tag
+        """Test playlist entry creation for a song with a disabled tag
+
+        The creation is forbidden.
         """
         # Login as playlist user
         self.authenticate(self.p_user)
@@ -192,15 +193,17 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.tag1.save()
 
         # Post new playlist entry with disabled Tag 1
-        response = self.client.post(self.url, {"song": self.song1.id})
+        response = self.client.post(self.url, {"song_id": self.song1.id})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_post_create_playlist_entry_disabled_tag_manager(self):
-        """Test to verify playlist entry creation is allowed for a song with a
-        disabled tag when the user is manager for playlist and library
+        """Test playlist entry for song with a disabled tag if manager
+
+        The user is manager for playlist and library, the creation is allowed.
         """
         # Login as playlist user
-        user = self.create_user('manager', playlist_level='m',
+        user = self.create_user('manager',
+                                playlist_level='m',
                                 library_level='m')
         self.authenticate(user)
 
@@ -209,7 +212,7 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         self.tag1.save()
 
         # Post new playlist entry with disabled Tag 1
-        response = self.client.post(self.url, {"song": self.song1.id})
+        response = self.client.post(self.url, {"song_id": self.song1.id})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 

--- a/dakara_server/playlist/tests_playlist_entry.py
+++ b/dakara_server/playlist/tests_playlist_entry.py
@@ -3,10 +3,14 @@ from datetime import datetime, timedelta
 
 from django.core.urlresolvers import reverse
 from django.utils.dateparse import parse_datetime
+from django.contrib.auth import get_user_model
 from rest_framework import status
 
 from .base_test import BaseAPITestCase, tz
 from .models import PlaylistEntry, Player
+
+
+UserModel = get_user_model()
 
 
 class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
@@ -203,8 +207,8 @@ class PlaylistEntryListViewListCreateAPIViewTestCase(BaseAPITestCase):
         """
         # Login as playlist user
         user = self.create_user('manager',
-                                playlist_level='m',
-                                library_level='m')
+                                playlist_level=UserModel.MANAGER,
+                                library_level=UserModel.MANAGER)
         self.authenticate(user)
 
         # Set tag1 disabled

--- a/dakara_server/playlist/views.py
+++ b/dakara_server/playlist/views.py
@@ -16,10 +16,10 @@ from rest_framework.generics import (
     RetrieveUpdateAPIView,
 )
 
-from . import models
-from . import serializers
-from . import permissions
-from . import views_device as device # noqa F401
+from playlist import models
+from playlist import serializers
+from playlist import permissions
+from playlist import views_device as device # noqa F401
 
 tz = timezone.get_default_timezone()
 
@@ -60,7 +60,7 @@ class PlaylistEntryListView(ListCreateAPIView):
         if self.request.method == 'POST':
             return serializers.PlaylistEntrySerializer
 
-        return serializers.PlaylistEntriesReadSerializer
+        return serializers.PlaylistEntriesWithDateEndSerializer
 
     def get_queryset(self):
         player = models.Player.get_or_create()
@@ -103,14 +103,14 @@ class PlaylistEntryListView(ListCreateAPIView):
                 detail="Playlist is full, please retry later."
             )
 
-        return super().create(request)
+        return super().post(request)
 
 
 class PlaylistPlayedEntryListView(ListAPIView):
     """List of played entries
     """
     pagination_class = PlaylistEntryPagination
-    serializer_class = serializers.PlaylistPlayedEntryReadSerializer
+    serializer_class = serializers.PlaylistPlayedEntryWithDatePlayedSerializer
     queryset = models.PlaylistEntry.objects.filter(was_played=True) \
         .order_by('date_created')
 
@@ -126,7 +126,7 @@ class PlayerStatusView(APIView):
         Create one if it doesn't exist.
         """
         player = models.Player.get_or_create()
-        serializer = serializers.PlayerDetailsSerializer(
+        serializer = serializers.PlayerStatusSerializer(
             player,
             context={'request': request}
         )
@@ -184,7 +184,7 @@ class PlayerErrorsPoolView(APIView):
         """Send player error pool
         """
         player_errors_pool = models.PlayerErrorsPool.get_or_create()
-        serializer = serializers.PlayerErrorsPoolSerializer(
+        serializer = serializers.PlayerErrorSerializer(
             player_errors_pool.dump(),
             many=True,
             context={'request': request}

--- a/dakara_server/playlist/views_device.py
+++ b/dakara_server/playlist/views_device.py
@@ -6,9 +6,9 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from . import models
-from . import serializers
-from . import permissions
+from playlist import models
+from playlist.serializers import device as serializers
+from playlist import permissions
 
 tz = timezone.get_default_timezone()
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ class PlayerDeviceView(APIView):
         else:
             entry = None
 
-        serializer = serializers.PlaylistEntryForPlayerSerializer(entry)
+        serializer = serializers.PlaylistEntrySerializer(entry)
 
         return Response(
             serializer.data,

--- a/dakara_server/users/models.py
+++ b/dakara_server/users/models.py
@@ -45,9 +45,11 @@ class DakaraUser(AbstractUser):
     objects = DakaraUserManager()
 
     # permission levels per application
+    USER = 'u'
+    MANAGER = 'm'
     LEVELS_GENERICS = [
-        ("u", "User"),
-        ("m", "Manager"),
+        (USER, "User"),
+        (MANAGER, "Manager"),
     ]
 
     # role for Users app
@@ -65,8 +67,9 @@ class DakaraUser(AbstractUser):
     )
 
     # role for Playlist app
+    PLAYER = 'p'
     LEVELS_PLAYLIST = [
-        ("p", "Player"),
+        (PLAYER, "Player"),
     ]
 
     LEVELS_PLAYLIST.extend(LEVELS_GENERICS)

--- a/dakara_server/users/models.py
+++ b/dakara_server/users/models.py
@@ -47,32 +47,38 @@ class DakaraUser(AbstractUser):
     # permission levels per application
     USER = 'u'
     MANAGER = 'm'
-    LEVELS_GENERICS = [
+    PLAYER = 'p'
+
+    # role for Users app
+    LEVELS_USERS = [
         (USER, "User"),
         (MANAGER, "Manager"),
     ]
 
-    # role for Users app
     users_permission_level = models.CharField(
         max_length=1,
-        choices=LEVELS_GENERICS,
+        choices=LEVELS_USERS,
         null=True,
     )
 
     # role for Libraryapp
+    LEVELS_LIBRARY = [
+        (USER, "User"),
+        (MANAGER, "Manager"),
+    ]
     library_permission_level = models.CharField(
         max_length=1,
-        choices=LEVELS_GENERICS,
+        choices=LEVELS_LIBRARY,
         null=True,
     )
 
     # role for Playlist app
-    PLAYER = 'p'
     LEVELS_PLAYLIST = [
         (PLAYER, "Player"),
+        (USER, "User"),
+        (MANAGER, "Manager"),
     ]
 
-    LEVELS_PLAYLIST.extend(LEVELS_GENERICS)
     playlist_permission_level = models.CharField(
         max_length=1,
         choices=LEVELS_PLAYLIST,

--- a/dakara_server/users/models.py
+++ b/dakara_server/users/models.py
@@ -88,7 +88,8 @@ class DakaraUser(AbstractUser):
             return True
 
         # the manager level includes everyone else level, except for the player
-        if user_permission_level == 'm' and requested_permission_level != 'p':
+        if user_permission_level == self.MANAGER and \
+           requested_permission_level != self.PLAYER:
             return True
 
         return user_permission_level == requested_permission_level

--- a/dakara_server/users/permissions.py
+++ b/dakara_server/users/permissions.py
@@ -1,4 +1,8 @@
 from rest_framework import permissions
+from django.contrib.auth import get_user_model
+
+
+UserModel = get_user_model()
 
 
 class BasePermissionCustom(permissions.BasePermission):
@@ -42,7 +46,7 @@ class IsUsersManagerOrReadOnly(BasePermissionCustom):
 
     def has_permission_custom(self, request, view):
         # for manager
-        if request.user.has_users_permission_level('m'):
+        if request.user.has_users_permission_level(UserModel.MANAGER):
             return True
 
         # for safe methods only
@@ -72,7 +76,7 @@ class IsUsersManagerOrSelfOrReadOnly(BasePermissionCustom):
             return True
 
         # for manager
-        if request.user.has_users_permission_level('m'):
+        if request.user.has_users_permission_level(UserModel.MANAGER):
             return True
 
         # if the object belongs to the user

--- a/dakara_server/users/serializers.py
+++ b/dakara_server/users/serializers.py
@@ -16,6 +16,9 @@ class UserForPublicSerializer(serializers.ModelSerializer):
             'id',
             'username',
         )
+        read_only_fields = (
+            'username',
+        )
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -33,7 +36,6 @@ class UserSerializer(serializers.ModelSerializer):
             'playlist_permission_level'
         )
         read_only_fields = (
-            'id',
             'is_superuser',
             'users_permission_level',
             'library_permission_level',

--- a/dakara_server/users/serializers.py
+++ b/dakara_server/users/serializers.py
@@ -4,23 +4,7 @@ from django.contrib.auth import (
     update_session_auth_hash,
 )
 
-from .models import DakaraUser
-
 UserModel = get_user_model()
-
-
-class PermissionLevelField(serializers.ChoiceField):
-    """Apps permission level field
-
-    It does the dirty job in one place.
-    """
-
-    def __init__(self, target, *args, **kwargs):
-        super().__init__(
-            *args,
-            choices=DakaraUser._meta.get_field(target).choices,
-            **kwargs
-        )
 
 
 class UserDisplaySerializer(serializers.ModelSerializer):
@@ -37,24 +21,6 @@ class UserDisplaySerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     """Creation and view
     """
-    password = serializers.CharField(write_only=True)
-    id = serializers.IntegerField(read_only=True)
-    is_superuser = serializers.BooleanField(read_only=True)
-    users_permission_level = PermissionLevelField(
-        target="users_permission_level",
-        read_only=True
-    )
-
-    library_permission_level = PermissionLevelField(
-        target="library_permission_level",
-        read_only=True
-    )
-
-    playlist_permission_level = PermissionLevelField(
-        target="playlist_permission_level",
-        read_only=True
-    )
-
     class Meta:
         model = UserModel
         fields = (
@@ -66,6 +32,16 @@ class UserSerializer(serializers.ModelSerializer):
             'library_permission_level',
             'playlist_permission_level'
         )
+        read_only_fields = (
+            'id',
+            'is_superuser',
+            'users_permission_level',
+            'library_permission_level',
+            'playlist_permission_level'
+        )
+        extra_kwargs = {
+            'password': {'write_only': True}
+        }
 
     def validate_username(self, value):
         """Check username unicity in case insensitive way
@@ -84,7 +60,7 @@ class UserSerializer(serializers.ModelSerializer):
         UserManager's secured user creation methods.
         """
         instance = UserModel.objects.create_user(**validated_data)
-        instance.playlist_permission_level = 'u'
+        instance.playlist_permission_level = UserModel.USER
         instance.save()
 
         return instance
@@ -98,13 +74,14 @@ class PasswordSerializer(serializers.ModelSerializer):
 
     For editing other user info, create another serializer.
     """
-
-    password = serializers.CharField(write_only=True, required=True)
     old_password = serializers.CharField(write_only=True, required=True)
 
     class Meta:
         model = UserModel
         fields = ('password', 'old_password')
+        extra_kwargs = {
+            'password': {'write_only': True, 'required': True}
+        }
 
     def validate_old_password(self, value):
         """Check old password is correct

--- a/dakara_server/users/serializers.py
+++ b/dakara_server/users/serializers.py
@@ -7,7 +7,7 @@ from django.contrib.auth import (
 UserModel = get_user_model()
 
 
-class UserDisplaySerializer(serializers.ModelSerializer):
+class UserForPublicSerializer(serializers.ModelSerializer):
     """Display public data only
     """
     class Meta:
@@ -107,7 +107,7 @@ class PasswordSerializer(serializers.ModelSerializer):
         return instance
 
 
-class UserUpdateManagerSerializer(PasswordSerializer):
+class UserForManagerSerializer(PasswordSerializer):
     """Users edition for managers
 
     Can edit:

--- a/dakara_server/users/views.py
+++ b/dakara_server/users/views.py
@@ -5,8 +5,8 @@ from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 
 from library.views import LibraryPagination as UsersPagination
-from . import serializers
-from . import permissions
+from users import serializers
+from users import permissions
 
 
 UserModel = get_user_model()
@@ -18,12 +18,13 @@ class CurrentUserView(views.APIView):
     permission_classes = [
         IsAuthenticated
     ]
+    serializer_class = serializers.UserSerializer
 
     def get(self, request):
         """Retrieve the user
         """
         user = request.user
-        serializer = serializers.UserSerializer(user)
+        serializer = self.serializer_class(user)
 
         return Response(serializer.data)
 

--- a/dakara_server/users/views.py
+++ b/dakara_server/users/views.py
@@ -52,7 +52,7 @@ class UserView(generics.RetrieveUpdateDestroyAPIView):
 
     def get_serializer_class(self):
         if self.request.method in ('PUT', 'PATCH'):
-            return serializers.UserUpdateManagerSerializer
+            return serializers.UserForManagerSerializer
 
         return serializers.UserSerializer
 


### PR DESCRIPTION
Some serializers have been misused when created. This PR intends to correct them and by the way, simplify them. The changes are:

* [x] remove `link_type_name` from the work link serializer, as this long name is directly deducible from `link_type` (it will be hard-coded in the client and in the player);
* [x] remove fields that were overloaded to add some properties (`read_only`, `write_only` and `required`), as the same effect can be obtained with attributes to the `Meta` class. Overloaded fields obliged to guess their type and perform some hacks to set up some of them (like the permission fields);
* [x] define the requested amount of lines of lyrics by a parameter, instead of a constant;
* [x] rename serializers for better clarity.

Some other improvements have been done:

* [x] correct the type for Image song (previously written Image so*m*g);
* [x] store permission values in the `DakaraUser` model: `USER`, `MANAGER` and `PLAYER` are available instead of `"u"`, `"m"` and `"p"`, use it in the whole project;
* [x] tidy up the `DakaraUser` model;
* [x] improve tests.

As a side-effect, the key to designate a song when adding to the playlist is now `song_id` instead of `song`.
