### PR TITLE
Setup Windows CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ branches:
     - master
     - develop
 
+# command to install system dependencies
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y ffmpeg
+
 # command to install python dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
 
 # command to install system dependencies
 before_install:
+  - "sudo add-apt-repository -y ppa:mc3man/trusty-media"
   - sudo apt-get -qq update
   - sudo apt-get install -y ffmpeg
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dakara server
 
-[![Build Status](https://travis-ci.org/DakaraProject/dakara-server.svg?branch=develop)](https://travis-ci.org/DakaraProject/dakara-server)
+[![Travis CI Build Status](https://travis-ci.org/DakaraProject/dakara-server.svg?branch=develop)](https://travis-ci.org/DakaraProject/dakara-server)
+[![Appveyor CI Build status](https://ci.appveyor.com/api/projects/status/2wdia71y3dwsqywp?svg=true)](https://ci.appveyor.com/project/neraste/dakara-server)
 
 Server for the Dakara project.
 
@@ -17,6 +18,8 @@ Installation guidelines are provided over here:
 * Python3, to make everything up and running;
 * [ffmpeg](https://www.ffmpeg.org/), to extract lyrics and extract metadata from files (preferred way);
 * [MediaInfo](https://mediaarea.net/fr/MediaInfo/), to extract metadata from files (slower, alternative way, may not work on Windows).
+
+Linux and Windows are supported.
 
 #### Virtual environment
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+version: 1.2.0-{build}
+
+build: false
+
+# restrict to branches
+branches:
+  only:
+  - develop
+  - master
+
+environment:
+  # setup special environment variable for Appveyor CI test environment
+  # it is used to disable some tests that can be harmful in this context
+  APPVEYOR_CI_ENV: 1
+
+  # setup tests matrix
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.3"
+      PYTHON_ARCH: "64"
+
+# check current python version
+init:
+  - "echo %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+# command to install system and python dependencies
+install:
+  - "cinst ffmpeg"
+  - "%PYTHON%/Scripts/pip.exe install -r requirements.txt"
+
+# command to run tests
+test_script:
+  - "cd dakara_server && %PYTHON%/python.exe ./manage.py test -v 2"
+  - "%PYTHON%/Scripts/flake8.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,5 @@ install:
 
 # command to run tests
 test_script:
-  - "cd dakara_server && %PYTHON%/python.exe ./manage.py test -v 2"
+  - "cd dakara_server && %PYTHON%/python.exe ./manage.py test -v 2 & cd .."
   - "%PYTHON%/Scripts/flake8.exe"

--- a/dakara_server/library/tests_command_createtags.py
+++ b/dakara_server/library/tests_command_createtags.py
@@ -1,9 +1,12 @@
-from tempfile import NamedTemporaryFile
+import os
 
 from django.core.management import call_command
 from django.test import TestCase
 
 from .models import SongTag
+
+RESSOURCES_DIR = "tests_ressources"
+APP_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class CreatetagsCommandTestCase(TestCase):
@@ -11,32 +14,26 @@ class CreatetagsCommandTestCase(TestCase):
         """Test create tags command
         """
         # Pre-Assertions
+        self.assertEqual(SongTag.objects.count(), 0)
+
+        config_file_path = os.path.join(
+            APP_DIR,
+            RESSOURCES_DIR,
+            'createtags_command_config.yaml'
+        )
+
+        # Call command
+        args = [config_file_path]
+        opts = {'quiet': True}
+        call_command('createtags', *args, **opts)
+
+        # Post-Assertions
         tags = SongTag.objects.order_by('name')
-        self.assertEqual(len(tags), 0)
-
-        file_content = """tags:
-  - name: TAGNAME1
-    color_hue: 0
-  - name: TAGNAME2
-    color_hue: 5"""
-
-        # Create temporary config file
-        with NamedTemporaryFile(mode='wt') as config_file:
-            config_file.write(file_content)
-            config_file.flush()
-
-            # Call command
-            args = [config_file.name]
-            opts = {'quiet': True}
-            call_command('createtags', *args, **opts)
-
-            # Post-Assertions
-            tags = SongTag.objects.order_by('name')
-            self.assertEqual(len(tags), 2)
-            self.assertEqual(tags[0].name, "TAGNAME1")
-            self.assertEqual(tags[0].color_hue, 0)
-            self.assertEqual(tags[1].name, "TAGNAME2")
-            self.assertEqual(tags[1].color_hue, 5)
+        self.assertEqual(len(tags), 2)
+        self.assertEqual(tags[0].name, "TAGNAME1")
+        self.assertEqual(tags[0].color_hue, 0)
+        self.assertEqual(tags[1].name, "TAGNAME2")
+        self.assertEqual(tags[1].color_hue, 5)
 
     def test_createtags_command_prune(self):
         """Test create tags command with existing tags and prune option
@@ -62,30 +59,25 @@ class CreatetagsCommandTestCase(TestCase):
         self.assertEqual(tags[0].color_hue, None)
         self.assertEqual(tags[1].name, "TAGOLD")
 
-        file_content = """tags:
-  - name: TAGNAME1
-    color_hue: 0
-  - name: TAGNAME2
-    color_hue: 5"""
+        config_file_path = os.path.join(
+            APP_DIR,
+            RESSOURCES_DIR,
+            'createtags_command_config.yaml'
+        )
 
-        # Create temporary config file
-        with NamedTemporaryFile(mode='wt') as config_file:
-            config_file.write(file_content)
-            config_file.flush()
+        # Call command
+        args = [config_file_path]
+        opts = {'quiet': True, 'prune': True}
+        call_command('createtags', *args, **opts)
 
-            # Call command
-            args = [config_file.name]
-            opts = {'quiet': True, 'prune': True}
-            call_command('createtags', *args, **opts)
-
-            # Post-Assertions
-            tags = SongTag.objects.order_by('name')
-            # Only the two tags from config file
-            self.assertEqual(len(tags), 2)
-            # Tag 1 has updated color id but same id
-            self.assertEqual(tags[0].name, "TAGNAME1")
-            self.assertEqual(tags[0].id, tag1.id)
-            self.assertEqual(tags[0].color_hue, 0)
-            # Tag 2 was created
-            self.assertEqual(tags[1].name, "TAGNAME2")
-            self.assertEqual(tags[1].color_hue, 5)
+        # Post-Assertions
+        tags = SongTag.objects.order_by('name')
+        # Only the two tags from config file
+        self.assertEqual(len(tags), 2)
+        # Tag 1 has updated color id but same id
+        self.assertEqual(tags[0].name, "TAGNAME1")
+        self.assertEqual(tags[0].id, tag1.id)
+        self.assertEqual(tags[0].color_hue, 0)
+        # Tag 2 was created
+        self.assertEqual(tags[1].name, "TAGNAME2")
+        self.assertEqual(tags[1].color_hue, 5)

--- a/dakara_server/library/tests_command_createworktypes.py
+++ b/dakara_server/library/tests_command_createworktypes.py
@@ -1,9 +1,12 @@
-from tempfile import NamedTemporaryFile
+import os
 
 from django.core.management import call_command
 from django.test import TestCase
 
 from .models import WorkType
+
+RESSOURCES_DIR = "tests_ressources"
+APP_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class CommandsTestCase(TestCase):
@@ -11,40 +14,30 @@ class CommandsTestCase(TestCase):
         """Test create work types command
         """
         # Pre-Assertions
+        self.assertEqual(WorkType.objects.count(), 0)
+
+        config_file_path = os.path.join(
+            APP_DIR,
+            RESSOURCES_DIR,
+            'createworktypes_command_config.yaml'
+        )
+
+        # Call command
+        args = [config_file_path]
+        opts = {'quiet': True}
+        call_command('createworktypes', *args, **opts)
+
+        # Post-Assertions
         work_types = WorkType.objects.order_by('query_name')
-        self.assertEqual(len(work_types), 0)
-
-        file_content = """worktypes:
-  - query_name: work-type-one
-    name: Work type one
-    name_plural: Work type one plural
-    icon_name: elephant
-  - query_name: work-type-two
-    name: Work type two
-    name_plural: Work type two plural
-    icon_name: cat"""
-
-        # Create temporary config file
-        with NamedTemporaryFile(mode='wt') as config_file:
-            config_file.write(file_content)
-            config_file.flush()
-
-            # Call command
-            args = [config_file.name]
-            opts = {'quiet': True}
-            call_command('createworktypes', *args, **opts)
-
-            # Post-Assertions
-            work_types = WorkType.objects.order_by('query_name')
-            self.assertEqual(len(work_types), 2)
-            self.assertEqual(work_types[0].query_name, "work-type-one")
-            self.assertEqual(work_types[0].name, "Work type one")
-            self.assertEqual(work_types[0].name_plural, "Work type one plural")
-            self.assertEqual(work_types[0].icon_name, "elephant")
-            self.assertEqual(work_types[1].query_name, "work-type-two")
-            self.assertEqual(work_types[1].name, "Work type two")
-            self.assertEqual(work_types[1].name_plural, "Work type two plural")
-            self.assertEqual(work_types[1].icon_name, "cat")
+        self.assertEqual(len(work_types), 2)
+        self.assertEqual(work_types[0].query_name, "work-type-one")
+        self.assertEqual(work_types[0].name, "Work type one")
+        self.assertEqual(work_types[0].name_plural, "Work type one plural")
+        self.assertEqual(work_types[0].icon_name, "elephant")
+        self.assertEqual(work_types[1].query_name, "work-type-two")
+        self.assertEqual(work_types[1].name, "Work type two")
+        self.assertEqual(work_types[1].name_plural, "Work type two plural")
+        self.assertEqual(work_types[1].icon_name, "cat")
 
     def test_createworktypes_command_prune(self):
         """Test create work types command with existing work types and prune
@@ -71,39 +64,30 @@ class CommandsTestCase(TestCase):
         self.assertEqual(work_types[0].query_name, "work-type-one")
         self.assertEqual(work_types[1].query_name, "work-type-wrong")
 
-        file_content = """worktypes:
-  - query_name: work-type-one
-    name: Work type one
-    name_plural: Work type one plural
-    icon_name: elephant
-  - query_name: work-type-two
-    name: Work type two
-    name_plural: Work type two plural
-    icon_name: cat"""
+        config_file_path = os.path.join(
+            APP_DIR,
+            RESSOURCES_DIR,
+            'createworktypes_command_config.yaml'
+        )
 
-        # Create temporary config file
-        with NamedTemporaryFile(mode='wt') as config_file:
-            config_file.write(file_content)
-            config_file.flush()
+        # Call command
+        args = [config_file_path]
+        opts = {'quiet': True, 'prune': True}
+        call_command('createworktypes', *args, **opts)
 
-            # Call command
-            args = [config_file.name]
-            opts = {'quiet': True, 'prune': True}
-            call_command('createworktypes', *args, **opts)
+        # Post-Assertions
+        work_types = WorkType.objects.order_by('query_name')
 
-            # Post-Assertions
-            work_types = WorkType.objects.order_by('query_name')
-
-            # Only the two work types from config file
-            self.assertEqual(len(work_types), 2)
-            # Work type one, has been updated, but has kept his id
-            self.assertEqual(work_types[0].query_name, "work-type-one")
-            self.assertEqual(work_types[0].id, work_type_one.id)
-            self.assertEqual(work_types[0].name, "Work type one")
-            self.assertEqual(work_types[0].name_plural, "Work type one plural")
-            self.assertEqual(work_types[0].icon_name, "elephant")
-            # Work type two has been created
-            self.assertEqual(work_types[1].query_name, "work-type-two")
-            self.assertEqual(work_types[1].name, "Work type two")
-            self.assertEqual(work_types[1].name_plural, "Work type two plural")
-            self.assertEqual(work_types[1].icon_name, "cat")
+        # Only the two work types from config file
+        self.assertEqual(len(work_types), 2)
+        # Work type one, has been updated, but has kept his id
+        self.assertEqual(work_types[0].query_name, "work-type-one")
+        self.assertEqual(work_types[0].id, work_type_one.id)
+        self.assertEqual(work_types[0].name, "Work type one")
+        self.assertEqual(work_types[0].name_plural, "Work type one plural")
+        self.assertEqual(work_types[0].icon_name, "elephant")
+        # Work type two has been created
+        self.assertEqual(work_types[1].query_name, "work-type-two")
+        self.assertEqual(work_types[1].name, "Work type two")
+        self.assertEqual(work_types[1].name_plural, "Work type two plural")
+        self.assertEqual(work_types[1].icon_name, "cat")

--- a/dakara_server/library/tests_ressources/createtags_command_config.yaml
+++ b/dakara_server/library/tests_ressources/createtags_command_config.yaml
@@ -1,0 +1,5 @@
+tags:
+  - name: TAGNAME1
+    color_hue: 0
+  - name: TAGNAME2
+    color_hue: 5

--- a/dakara_server/library/tests_ressources/createworktypes_command_config.yaml
+++ b/dakara_server/library/tests_ressources/createworktypes_command_config.yaml
@@ -1,0 +1,9 @@
+worktypes:
+  - query_name: work-type-one
+    name: Work type one
+    name_plural: Work type one plural
+    icon_name: elephant
+  - query_name: work-type-two
+    name: Work type two
+    name_plural: Work type two plural
+    icon_name: cat


### PR DESCRIPTION
This PR aims to support the project on Windows. Some adaptations were made and the CI test server (Appveyor) has been set up.

Adaptations:
- [x] Create test config files for commands `createtags` and `createworktypes` (previously, they were generated in a temp file, but Windows file locks prevent a second access to them).

Appveyor CI:
- [x] Setup config file;
- [x] Update readme and so on;
- [ ] Setup DakaraProject account.