### PR TITLE
Modular permissions

### DIFF
--- a/dakara_server/dakara_server/settings/base.py
+++ b/dakara_server/dakara_server/settings/base.py
@@ -110,6 +110,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ),
+    "DEFAULT_PAGINATION_CLASS": "internal.pagination.PageNumberPaginationCustom",
     "PAGE_SIZE": 10,
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }

--- a/dakara_server/internal/pagination.py
+++ b/dakara_server/internal/pagination.py
@@ -1,0 +1,21 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class PageNumberPaginationCustom(PageNumberPagination):
+    """Pagination
+
+    Gives current page number and last page number.
+    """
+
+    def get_paginated_response(self, data):
+        return Response(
+            {
+                "pagination": {
+                    "current": self.page.number,
+                    "last": self.page.paginator.num_pages,
+                },
+                "count": self.page.paginator.count,
+                "results": data,
+            }
+        )

--- a/dakara_server/internal/permissions.py
+++ b/dakara_server/internal/permissions.py
@@ -3,6 +3,15 @@ from rest_framework import permissions
 
 class BasePermissionCustom(permissions.BasePermission):
     """Restrict object permission to access permission
+
+    The main problem of `BasePermission` is that the default value for
+    `has_permission_object` is True. This leads to problem when one permission
+    class, that redefines `has_permission_object`, is combined with another
+    one, that does not, with the `or` operator: the resulting
+    `has_permission_object` value is alway True.
+
+    Returning the same value as `has_permission` is for now the least dirty way
+    to avoid this problem.
     """
 
     def has_object_permission(self, request, view, obj):

--- a/dakara_server/internal/permissions.py
+++ b/dakara_server/internal/permissions.py
@@ -1,0 +1,49 @@
+from rest_framework import permissions
+
+
+class BasePermissionCustom(permissions.BasePermission):
+    """Restrict object permission to access permission
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
+class IsReadOnly(BasePermissionCustom):
+    """Allow access if request is GET, OPTION...
+    """
+
+    def has_permission(self, request, view):
+        return request.method in permissions.SAFE_METHODS
+
+
+class IsPost(BasePermissionCustom):
+    """Allow access if request is POST
+    """
+
+    def has_permission(self, request, view):
+        return request.method == "POST"
+
+
+class IsPut(BasePermissionCustom):
+    """Allow access if request is PUT
+    """
+
+    def has_permission(self, request, view):
+        return request.method == "PUT"
+
+
+class IsPatch(BasePermissionCustom):
+    """Allow access if request is PATCH
+    """
+
+    def has_permission(self, request, view):
+        return request.method == "PATCH"
+
+
+class IsDelete(BasePermissionCustom):
+    """Allow access if request is DELETE
+    """
+
+    def has_permission(self, request, view):
+        return request.method == "DELETE"

--- a/dakara_server/library/permissions.py
+++ b/dakara_server/library/permissions.py
@@ -11,12 +11,7 @@ class IsLibraryManager(BasePermissionCustom):
     """
 
     def has_permission(self, request, view):
-        # for super user
-        if request.user.is_superuser:
-            return True
-
-        # for manager
-        return request.user.has_library_permission_level(UserModel.MANAGER)
+        return request.user.is_superuser or request.user.is_library_manager
 
 
 class IsLibraryUser(BasePermissionCustom):
@@ -24,9 +19,4 @@ class IsLibraryUser(BasePermissionCustom):
     """
 
     def has_permission(self, request, view):
-        # for super user
-        if request.user.is_superuser:
-            return True
-
-        # for user
-        return request.user.has_library_permission_level(UserModel.USER)
+        return request.user.is_superuser or request.user.is_library_user

--- a/dakara_server/library/permissions.py
+++ b/dakara_server/library/permissions.py
@@ -15,8 +15,9 @@ class IsLibraryManager(BasePermissionCustom):
 
 
 class IsLibraryUser(BasePermissionCustom):
-    """Allow access if user is super user or library user
+    """Allow access if user is super user or library manager/user
     """
 
     def has_permission(self, request, view):
-        return request.user.is_superuser or request.user.is_library_user
+        user = request.user
+        return user.is_superuser or user.is_library_manager or user.is_library_user

--- a/dakara_server/library/permissions.py
+++ b/dakara_server/library/permissions.py
@@ -1,26 +1,32 @@
-from rest_framework import permissions
 from django.contrib.auth import get_user_model
 
-from users.permissions import BasePermissionCustom
+from internal.permissions import BasePermissionCustom
 
 
 UserModel = get_user_model()
 
 
-class IsLibraryManagerOrReadOnly(BasePermissionCustom):
-    """Handle permissions for updating library
-
-    Permission scheme:
-        Superuser can do anything;
-        Library manager can do anything;
-        Authenticated can only display;
-        Unauthenticated user cannot see anything.
+class IsLibraryManager(BasePermissionCustom):
+    """Allow access if user is super user or library manager
     """
 
-    def has_permission_custom(self, request, view):
-        # for safe methods only
-        if request.method in permissions.SAFE_METHODS:
+    def has_permission(self, request, view):
+        # for super user
+        if request.user.is_superuser:
             return True
 
-        # for modification
+        # for manager
         return request.user.has_library_permission_level(UserModel.MANAGER)
+
+
+class IsLibraryUser(BasePermissionCustom):
+    """Allow access if user is super user or library user
+    """
+
+    def has_permission(self, request, view):
+        # for super user
+        if request.user.is_superuser:
+            return True
+
+        # for user
+        return request.user.has_library_permission_level(UserModel.USER)

--- a/dakara_server/library/views.py
+++ b/dakara_server/library/views.py
@@ -8,7 +8,6 @@ from rest_framework.generics import (
     ListAPIView,
 )
 
-from internal.pagination import PageNumberPaginationCustom
 from library import models
 from library import serializers
 from library.query_language import QueryLanguageParser
@@ -47,9 +46,7 @@ class SongListView(ListCreateAPIViewWithQueryParsed):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     serializer_class = serializers.SongSerializer
-    pagination_class = PageNumberPaginationCustom
 
     def get_queryset(self):
         """Search and filter the songs
@@ -168,7 +165,6 @@ class SongView(RetrieveUpdateDestroyAPIView):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     queryset = models.Song.objects.all()
     serializer_class = serializers.SongSerializer
 
@@ -178,9 +174,7 @@ class ArtistListView(ListCreateAPIViewWithQueryParsed):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     serializer_class = serializers.ArtistWithCountSerializer
-    pagination_class = PageNumberPaginationCustom
 
     def get_queryset(self):
         """Search and filter the artists
@@ -219,9 +213,7 @@ class WorkListView(ListCreateAPIViewWithQueryParsed):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     serializer_class = serializers.WorkSerializer
-    pagination_class = PageNumberPaginationCustom
 
     def get_queryset(self):
         """Search and filter the works
@@ -271,7 +263,6 @@ class WorkTypeListView(ListCreateAPIView):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     queryset = models.WorkType.objects.all().order_by(Lower("name"))
     serializer_class = serializers.WorkTypeSerializer
 
@@ -281,10 +272,8 @@ class SongTagListView(ListAPIView):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     queryset = models.SongTag.objects.all().order_by(Lower("name"))
     serializer_class = serializers.SongTagSerializer
-    pagination_class = PageNumberPaginationCustom
 
 
 class SongTagView(UpdateAPIView):
@@ -292,6 +281,5 @@ class SongTagView(UpdateAPIView):
     """
 
     permission_classes = (IsLibraryManagerOrReadOnly,)
-
     queryset = models.SongTag.objects.all()
     serializer_class = serializers.SongTagSerializer

--- a/dakara_server/library/views.py
+++ b/dakara_server/library/views.py
@@ -1,6 +1,7 @@
 from django.db.models.functions import Lower
 from django.db.models import Q
 from django.contrib.auth import get_user_model
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
     UpdateAPIView,
@@ -8,10 +9,11 @@ from rest_framework.generics import (
     ListAPIView,
 )
 
+from internal import permissions as internal_permissions
 from library import models
 from library import serializers
+from library import permissions
 from library.query_language import QueryLanguageParser
-from library.permissions import IsLibraryManagerOrReadOnly
 
 
 UserModel = get_user_model()
@@ -45,7 +47,10 @@ class SongListView(ListCreateAPIViewWithQueryParsed):
     """List of songs
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     serializer_class = serializers.SongSerializer
 
     def get_queryset(self):
@@ -164,7 +169,10 @@ class SongView(RetrieveUpdateDestroyAPIView):
     """Edition and display of a song
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     queryset = models.Song.objects.all()
     serializer_class = serializers.SongSerializer
 
@@ -173,7 +181,10 @@ class ArtistListView(ListCreateAPIViewWithQueryParsed):
     """List of artists
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     serializer_class = serializers.ArtistWithCountSerializer
 
     def get_queryset(self):
@@ -212,7 +223,10 @@ class WorkListView(ListCreateAPIViewWithQueryParsed):
     """List of works
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     serializer_class = serializers.WorkSerializer
 
     def get_queryset(self):
@@ -262,7 +276,10 @@ class WorkTypeListView(ListCreateAPIView):
     """List of work types
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     queryset = models.WorkType.objects.all().order_by(Lower("name"))
     serializer_class = serializers.WorkTypeSerializer
 
@@ -271,7 +288,10 @@ class SongTagListView(ListAPIView):
     """List of song tags
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     queryset = models.SongTag.objects.all().order_by(Lower("name"))
     serializer_class = serializers.SongTagSerializer
 
@@ -280,6 +300,9 @@ class SongTagView(UpdateAPIView):
     """Update a song tag
     """
 
-    permission_classes = (IsLibraryManagerOrReadOnly,)
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsLibraryManager | internal_permissions.IsReadOnly,
+    ]
     queryset = models.SongTag.objects.all()
     serializer_class = serializers.SongTagSerializer

--- a/dakara_server/library/views.py
+++ b/dakara_server/library/views.py
@@ -60,9 +60,7 @@ class SongListView(ListCreateAPIViewWithQueryParsed):
 
         # hide all songs with disabled tags for non-managers or non-superusers
         user = self.request.user
-        if not (
-            user.is_superuser or user.has_library_permission_level(UserModel.MANAGER)
-        ):
+        if not (user.is_superuser or user.is_library_manager):
             query_set = query_set.exclude(tags__disabled=True)
 
         # if 'query' is in the query string then perform search otherwise

--- a/dakara_server/library/views.py
+++ b/dakara_server/library/views.py
@@ -1,8 +1,6 @@
 from django.db.models.functions import Lower
 from django.db.models import Q
 from django.contrib.auth import get_user_model
-from rest_framework.pagination import PageNumberPagination
-from rest_framework.response import Response
 from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
     UpdateAPIView,
@@ -10,6 +8,7 @@ from rest_framework.generics import (
     ListAPIView,
 )
 
+from internal.pagination import PageNumberPaginationCustom
 from library import models
 from library import serializers
 from library.query_language import QueryLanguageParser
@@ -17,25 +16,6 @@ from library.permissions import IsLibraryManagerOrReadOnly
 
 
 UserModel = get_user_model()
-
-
-class LibraryPagination(PageNumberPagination):
-    """Pagination
-
-    Gives current page number and last page number.
-    """
-
-    def get_paginated_response(self, data):
-        return Response(
-            {
-                "pagination": {
-                    "current": self.page.number,
-                    "last": self.page.paginator.num_pages,
-                },
-                "count": self.page.paginator.count,
-                "results": data,
-            }
-        )
 
 
 class ListCreateAPIViewWithQueryParsed(ListCreateAPIView):
@@ -69,7 +49,7 @@ class SongListView(ListCreateAPIViewWithQueryParsed):
     permission_classes = (IsLibraryManagerOrReadOnly,)
 
     serializer_class = serializers.SongSerializer
-    pagination_class = LibraryPagination
+    pagination_class = PageNumberPaginationCustom
 
     def get_queryset(self):
         """Search and filter the songs
@@ -200,7 +180,7 @@ class ArtistListView(ListCreateAPIViewWithQueryParsed):
     permission_classes = (IsLibraryManagerOrReadOnly,)
 
     serializer_class = serializers.ArtistWithCountSerializer
-    pagination_class = LibraryPagination
+    pagination_class = PageNumberPaginationCustom
 
     def get_queryset(self):
         """Search and filter the artists
@@ -241,7 +221,7 @@ class WorkListView(ListCreateAPIViewWithQueryParsed):
     permission_classes = (IsLibraryManagerOrReadOnly,)
 
     serializer_class = serializers.WorkSerializer
-    pagination_class = LibraryPagination
+    pagination_class = PageNumberPaginationCustom
 
     def get_queryset(self):
         """Search and filter the works
@@ -304,7 +284,7 @@ class SongTagListView(ListAPIView):
 
     queryset = models.SongTag.objects.all().order_by(Lower("name"))
     serializer_class = serializers.SongTagSerializer
-    pagination_class = LibraryPagination
+    pagination_class = PageNumberPaginationCustom
 
 
 class SongTagView(UpdateAPIView):

--- a/dakara_server/playlist/consumers.py
+++ b/dakara_server/playlist/consumers.py
@@ -62,7 +62,7 @@ class PlaylistDeviceConsumer(DakaraJsonWebsocketConsumer):
             return
 
         # ensure user is player
-        if not self.scope["user"].has_playlist_permission_level(UserModel.PLAYER):
+        if not self.scope["user"].is_player:
             self.close()
             logger.error("Invalid user tries to connect to playlist " "device consumer")
             return

--- a/dakara_server/playlist/permissions.py
+++ b/dakara_server/playlist/permissions.py
@@ -15,12 +15,7 @@ class IsPlaylistManager(BasePermissionCustom):
     """
 
     def has_permission(self, request, view):
-        # for super user
-        if request.user.is_superuser:
-            return True
-
-        # for manager
-        return request.user.has_playlist_permission_level(UserModel.MANAGER)
+        return request.user.is_superuser or request.user.is_playlist_manager
 
 
 class IsPlaylistUser(BasePermissionCustom):
@@ -28,12 +23,7 @@ class IsPlaylistUser(BasePermissionCustom):
     """
 
     def has_permission(self, request, view):
-        # for super user
-        if request.user.is_superuser:
-            return True
-
-        # for user
-        return request.user.has_playlist_permission_level(UserModel.USER)
+        return request.user.is_superuser or request.user.is_playlist_user
 
 
 class IsPlayer(BasePermissionCustom):
@@ -41,12 +31,7 @@ class IsPlayer(BasePermissionCustom):
     """
 
     def has_permission(self, request, view):
-        # for super user
-        if request.user.is_superuser:
-            return True
-
-        # for player
-        return request.user.has_playlist_permission_level(UserModel.PLAYER)
+        return request.user.is_superuser or request.user.is_player
 
 
 class IsOwner(permissions.BasePermission):

--- a/dakara_server/playlist/permissions.py
+++ b/dakara_server/playlist/permissions.py
@@ -19,11 +19,12 @@ class IsPlaylistManager(BasePermissionCustom):
 
 
 class IsPlaylistUser(BasePermissionCustom):
-    """Allow access if the user is super user or playlist user
+    """Allow access if the user is super user or playlist manager/user
     """
 
     def has_permission(self, request, view):
-        return request.user.is_superuser or request.user.is_playlist_user
+        user = request.user
+        return user.is_superuser or user.is_playlist_manager or user.is_playlist_user
 
 
 class IsPlayer(BasePermissionCustom):

--- a/dakara_server/playlist/serializers.py
+++ b/dakara_server/playlist/serializers.py
@@ -16,9 +16,7 @@ class PlaylistEntrySerializer(serializers.ModelSerializer):
 
     # get related owner field
     # auto-set related owner field
-    owner = UserForPublicSerializer(
-        read_only=True, default=serializers.CurrentUserDefault()
-    )
+    owner = UserForPublicSerializer(read_only=True)
 
     # get related song field
     song = SongSerializer(many=False, read_only=True)

--- a/dakara_server/playlist/tests_player_command.py
+++ b/dakara_server/playlist/tests_player_command.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from .base_test import BaseAPITestCase
 
 
-class PLayerCommandViewTestCase(BaseAPITestCase):
+class PlayerCommandViewTestCase(BaseAPITestCase):
     """Test the commands given to the player
     """
 

--- a/dakara_server/playlist/views.py
+++ b/dakara_server/playlist/views.py
@@ -133,7 +133,8 @@ class PlaylistEntryListView(drf_generics.ListCreateAPIView):
 
         playlist_was_empty = models.PlaylistEntry.get_next() is None
 
-        super().perform_create(serializer)
+        # add the owner to the serializer and create data
+        serializer.save(owner=self.request.user)
 
         # TODO broadcast that a new entry has been created
 

--- a/dakara_server/playlist/views.py
+++ b/dakara_server/playlist/views.py
@@ -71,7 +71,9 @@ class PlaylistEntryListView(drf_generics.ListCreateAPIView):
     serializer_class = serializers.PlaylistEntrySerializer
     permission_classes = [
         IsAuthenticated,
-        permissions.IsPlaylistUser | internal_permissions.IsReadOnly,
+        permissions.IsPlaylistUser
+        | permissions.IsPlaylistManager
+        | internal_permissions.IsReadOnly,
         (permissions.IsPlaylistManager & library_permissions.IsLibraryManager)
         | permissions.IsSongEnabled,
         permissions.KaraokeIsNotStoppedOrReadOnly,
@@ -114,10 +116,8 @@ class PlaylistEntryListView(drf_generics.ListCreateAPIView):
         # we are creating the object (which obviously doesn't exist yet).
         karaoke = models.Karaoke.get_object()
 
-        if (
-            karaoke.date_stop is not None
-            and not self.request.user.has_playlist_permission_level(UserModel.MANAGER)
-            and not self.request.user.is_superuser
+        if karaoke.date_stop is not None and not (
+            self.request.user.is_playlist_manager or self.request.user.is_superuser
         ):
             # compute playlist end date
             playlist = self.filter_queryset(self.get_queryset())

--- a/dakara_server/playlist/views.py
+++ b/dakara_server/playlist/views.py
@@ -8,11 +8,11 @@ from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework import generics as drf_generics
 
+from internal.pagination import PageNumberPaginationCustom
 from playlist import models
 from playlist import serializers
 from playlist import permissions
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 UserModel = get_user_model()
 
 
-class PlaylistEntryPagination(PageNumberPagination):
+class PlaylistEntryPagination(PageNumberPaginationCustom):
     """Pagination setup for playlist entries
     """
 
@@ -402,7 +402,6 @@ class PlayerErrorView(drf_generics.ListCreateAPIView):
     permission_classes = [permissions.IsPlayerOrReadOnly]
     serializer_class = serializers.PlayerErrorSerializer
     queryset = models.PlayerError.objects.order_by("date_created")
-    pagination_class = PageNumberPagination
 
     def perform_create(self, serializer):
         """Create an error and perform other actions

--- a/dakara_server/playlist/views.py
+++ b/dakara_server/playlist/views.py
@@ -71,9 +71,7 @@ class PlaylistEntryListView(drf_generics.ListCreateAPIView):
     serializer_class = serializers.PlaylistEntrySerializer
     permission_classes = [
         IsAuthenticated,
-        permissions.IsPlaylistUser
-        | permissions.IsPlaylistManager
-        | internal_permissions.IsReadOnly,
+        permissions.IsPlaylistUser | internal_permissions.IsReadOnly,
         (permissions.IsPlaylistManager & library_permissions.IsLibraryManager)
         | permissions.IsSongEnabled,
         permissions.KaraokeIsNotStoppedOrReadOnly,

--- a/dakara_server/users/models.py
+++ b/dakara_server/users/models.py
@@ -70,37 +70,30 @@ class DakaraUser(AbstractUser):
         max_length=1, choices=LEVELS_PLAYLIST, null=True
     )
 
-    def _has_permission_level(self, user_permission_level, requested_permission_level):
-        """Check if the user has the requested app permission level
-        """
-        # the superuser can do anything
-        if self.is_superuser:
-            return True
+    @property
+    def is_users_user(self):
+        return self.users_permission_level == self.USER
 
-        # the manager level includes everyone else level, except for the player
-        if (
-            user_permission_level == self.MANAGER
-            and requested_permission_level != self.PLAYER
-        ):
-            return True
+    @property
+    def is_users_manager(self):
+        return self.users_permission_level == self.MANAGER
 
-        return user_permission_level == requested_permission_level
+    @property
+    def is_library_user(self):
+        return self.library_permission_level == self.USER
 
-    def has_users_permission_level(self, permission_level):
-        """Check if the user has the requested users permission level
-        """
-        return self._has_permission_level(self.users_permission_level, permission_level)
+    @property
+    def is_library_manager(self):
+        return self.library_permission_level == self.MANAGER
 
-    def has_library_permission_level(self, permission_level):
-        """Check if the user has the requested library permission level
-        """
-        return self._has_permission_level(
-            self.library_permission_level, permission_level
-        )
+    @property
+    def is_playlist_user(self):
+        return self.playlist_permission_level == self.USER
 
-    def has_playlist_permission_level(self, permission_level):
-        """Check if the user has the requested playlist permission level
-        """
-        return self._has_permission_level(
-            self.playlist_permission_level, permission_level
-        )
+    @property
+    def is_playlist_manager(self):
+        return self.playlist_permission_level == self.MANAGER
+
+    @property
+    def is_player(self):
+        return self.playlist_permission_level == self.PLAYER

--- a/dakara_server/users/permissions.py
+++ b/dakara_server/users/permissions.py
@@ -19,12 +19,7 @@ class IsUsersManager(BasePermissionCustom):
     """
 
     def has_permission(self, request, view):
-        # for super user
-        if request.user.is_superuser:
-            return True
-
-        # for manager
-        return request.user.has_users_permission_level(UserModel.MANAGER)
+        return request.user.is_superuser or request.user.is_users_manager
 
 
 class IsSelf(BasePermissionCustom):

--- a/dakara_server/users/permissions.py
+++ b/dakara_server/users/permissions.py
@@ -1,5 +1,6 @@
-from rest_framework import permissions
 from django.contrib.auth import get_user_model
+
+from internal.permissions import BasePermissionCustom
 
 
 UserModel = get_user_model()
@@ -13,121 +14,30 @@ class DummyRequest:
         self.__dict__.update(entries)
 
 
-class BasePermissionCustom(permissions.BasePermission):
-    """Base permission class for the project, check the basic permissions
-
-    Permission scheme:
-        Superuser can do anything;
-        Unauthenticated user cannot do anything.
-
-    The permission methods call a custom method for specific permissions.
+class IsUsersManager(BasePermissionCustom):
+    """Allow access if user is super user or user manager
     """
 
     def has_permission(self, request, view):
-        """Check the permission
-        """
-        # convert dict passed request to object
-        # idea from https://stackoverflow.com/a/1305663/4584444
-        if isinstance(request, dict):
-            request = DummyRequest(**request)
-
-        # if the user is not authenticated, deny access
-        if not request.user or not request.user.is_authenticated():
-            return False
-
-        # if the user is the superuser or the users manager, allow access
-        if request.user.is_superuser:
-            return True
-
-        # call specific permission check
-        return self.has_permission_custom(request, view)
-
-    def has_permission_custom(self, request, view):
-        """Stub for specific permissions check
-        """
-        return True
-
-
-class IsUsersManagerOrReadOnly(BasePermissionCustom):
-    """Handle permissions for the User app
-
-    Permission scheme:
-        Superuser can edit anything;
-        Users Manager can edit anything;
-        Authenticated user can only display data;
-        Unauthenticated user cannot see anything.
-    """
-
-    def has_permission_custom(self, request, view):
-        # for manager
-        if request.user.has_users_permission_level(UserModel.MANAGER):
-            return True
-
-        # for safe methods only
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        return False
-
-
-class IsUsersManagerOrSelfOrReadOnly(BasePermissionCustom):
-    """Handle permissions for the User app
-
-    Permission scheme:
-        Superuser can edit anything;
-        Users Manager can edit anything;
-        Authenticated user can edit self;
-        Unauthenticated user cannot see anything.
-    """
-
-    def has_object_permission(self, request, view, obj):
-        # for safe methods only
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        # if the user is the superuser, allow access
+        # for super user
         if request.user.is_superuser:
             return True
 
         # for manager
-        if request.user.has_users_permission_level(UserModel.MANAGER):
-            return True
-
-        # if the object belongs to the user
-        return obj == request.user
+        return request.user.has_users_permission_level(UserModel.MANAGER)
 
 
 class IsSelf(BasePermissionCustom):
-    """Handle permissions for the User app
-
-    Permission scheme:
-        Superuser can edit anything;
-        Authenticated user can only edit self;
-        Unauthenticated user cannot see anything.
+    """Allow access if user if the object
     """
 
     def has_object_permission(self, request, view, obj):
-        # if the object belongs to the user
         return obj == request.user
 
 
-class IsNotSelfOrReadOnly(BasePermissionCustom):
-    """Handle permissions for the User app
-
-    Permission scheme:
-        Superuser can edit anything;
-        Authenticated user cannot edit self;
-        Unauthenticated user cannot see anything.
+class IsNotSelf(IsSelf):
+    """Allow access if user is not the object
     """
 
     def has_object_permission(self, request, view, obj):
-        # for safe methods only
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        # if the user is the superuser, allow access
-        if request.user.is_superuser:
-            return True
-
-        # if the object belongs to someone else
-        return obj != request.user
+        return not super().has_object_permission(request, view, obj)

--- a/dakara_server/users/tests_models.py
+++ b/dakara_server/users/tests_models.py
@@ -1,0 +1,99 @@
+from unittest import TestCase
+
+from users.models import DakaraUser
+
+
+class DakaraUserTestCase(TestCase):
+    """Test the Dakara user object permissions
+    """
+
+    def test_users_permission_levels(self):
+        """Test the users app permission levels
+        """
+        # create a users user
+        user = DakaraUser(username="user", users_permission_level=DakaraUser.USER)
+
+        # assert their permissions
+        self.assertTrue(user.is_users_user)
+        self.assertFalse(user.is_users_manager)
+
+        # create a users manager
+        manager = DakaraUser(
+            username="manager", users_permission_level=DakaraUser.MANAGER
+        )
+
+        # assert their permissions
+        self.assertFalse(manager.is_users_user)
+        self.assertTrue(manager.is_users_manager)
+
+        # create a superuser
+        superuser = DakaraUser(username="root", is_superuser=True)
+
+        # assert their permissions
+        self.assertFalse(superuser.is_users_user)
+        self.assertFalse(superuser.is_users_manager)
+
+    def test_library_permission_levels(self):
+        """Test the library app permission levels
+        """
+        # create a library user
+        user = DakaraUser(username="user", library_permission_level=DakaraUser.USER)
+
+        # assert their permissions
+        self.assertTrue(user.is_library_user)
+        self.assertFalse(user.is_library_manager)
+
+        # create a library manager
+        manager = DakaraUser(
+            username="manager", library_permission_level=DakaraUser.MANAGER
+        )
+
+        # assert their permissions
+        self.assertFalse(manager.is_library_user)
+        self.assertTrue(manager.is_library_manager)
+
+        # create a superuser
+        superuser = DakaraUser(username="root", is_superuser=True)
+
+        # assert their permissions
+        self.assertFalse(superuser.is_library_user)
+        self.assertFalse(superuser.is_library_manager)
+
+    def test_playlist_permission_levels(self):
+        """Test the playlist app permission levels
+        """
+        # create a playlist user
+        user = DakaraUser(username="user", playlist_permission_level=DakaraUser.USER)
+
+        # assert their permissions
+        self.assertTrue(user.is_playlist_user)
+        self.assertFalse(user.is_playlist_manager)
+        self.assertFalse(user.is_player)
+
+        # create a playlist manager
+        manager = DakaraUser(
+            username="manager", playlist_permission_level=DakaraUser.MANAGER
+        )
+
+        # assert their permissions
+        self.assertFalse(manager.is_playlist_user)
+        self.assertTrue(manager.is_playlist_manager)
+        self.assertFalse(manager.is_player)
+
+        # create a player
+        player = DakaraUser(
+            username="player", playlist_permission_level=DakaraUser.PLAYER
+        )
+
+        # assert their permissions
+        self.assertFalse(player.is_playlist_user)
+        self.assertFalse(player.is_playlist_manager)
+        self.assertTrue(player.is_player)
+
+        # create a superuser
+        superuser = DakaraUser(username="root", is_superuser=True)
+
+        # assert their permissions
+        self.assertFalse(superuser.is_playlist_user)
+        self.assertFalse(superuser.is_playlist_manager)
+        self.assertFalse(superuser.is_player)

--- a/dakara_server/users/views.py
+++ b/dakara_server/users/views.py
@@ -4,6 +4,7 @@ from rest_framework import views
 from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 
+from internal import permissions as internal_permissions
 from users import serializers
 from users import permissions
 
@@ -34,7 +35,10 @@ class UserListView(generics.ListCreateAPIView):
     model = UserModel
     queryset = UserModel.objects.all().order_by("username")
     serializer_class = serializers.UserSerializer
-    permission_classes = [permissions.IsUsersManagerOrReadOnly]
+    permission_classes = [
+        IsAuthenticated,
+        permissions.IsUsersManager | internal_permissions.IsReadOnly,
+    ]
 
 
 class UserView(generics.RetrieveUpdateDestroyAPIView):
@@ -44,8 +48,9 @@ class UserView(generics.RetrieveUpdateDestroyAPIView):
     model = UserModel
     queryset = UserModel.objects.all()
     permission_classes = [
-        permissions.IsUsersManagerOrReadOnly,
-        permissions.IsNotSelfOrReadOnly,
+        IsAuthenticated,
+        permissions.IsUsersManager & permissions.IsNotSelf
+        | internal_permissions.IsReadOnly,
     ]
 
     def get_serializer_class(self):
@@ -62,4 +67,4 @@ class PasswordView(generics.UpdateAPIView):
     model = UserModel
     queryset = UserModel.objects.all()
     serializer_class = serializers.PasswordSerializer
-    permission_classes = [permissions.IsSelf]
+    permission_classes = [IsAuthenticated, permissions.IsSelf]

--- a/dakara_server/users/views.py
+++ b/dakara_server/users/views.py
@@ -4,7 +4,7 @@ from rest_framework import views
 from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 
-from library.views import LibraryPagination as UsersPagination
+from internal.pagination import PageNumberPaginationCustom
 from users import serializers
 from users import permissions
 
@@ -35,7 +35,7 @@ class UserListView(generics.ListCreateAPIView):
     model = UserModel
     queryset = UserModel.objects.all().order_by("username")
     serializer_class = serializers.UserSerializer
-    pagination_class = UsersPagination
+    pagination_class = PageNumberPaginationCustom
     permission_classes = [permissions.IsUsersManagerOrReadOnly]
 
 

--- a/dakara_server/users/views.py
+++ b/dakara_server/users/views.py
@@ -4,7 +4,6 @@ from rest_framework import views
 from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 
-from internal.pagination import PageNumberPaginationCustom
 from users import serializers
 from users import permissions
 
@@ -35,7 +34,6 @@ class UserListView(generics.ListCreateAPIView):
     model = UserModel
     queryset = UserModel.objects.all().order_by("username")
     serializer_class = serializers.UserSerializer
-    pagination_class = PageNumberPaginationCustom
     permission_classes = [permissions.IsUsersManagerOrReadOnly]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coreapi==2.3.3
 dj-database-url==0.5.0
 django-ordered-model==2.0.0
 Django==1.11.15
-djangorestframework==3.6.4
+djangorestframework==3.7.7
 flake8==3.5.0
 Markdown==2.6.11
 progressbar2==3.34.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coreapi==2.3.3
 dj-database-url==0.5.0
 django-ordered-model==2.0.0
 Django==1.11.15
-djangorestframework==3.8.2
+djangorestframework==3.9.0
 flake8==3.5.0
 Markdown==2.6.11
 progressbar2==3.34.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coreapi==2.3.3
 dj-database-url==0.5.0
 django-ordered-model==2.0.0
 Django==1.11.15
-djangorestframework==3.9.0
+djangorestframework==3.9.1
 flake8==3.5.0
 Markdown==2.6.11
 progressbar2==3.34.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coreapi==2.3.3
 dj-database-url==0.5.0
 django-ordered-model==2.0.0
 Django==1.11.15
-djangorestframework==3.7.7
+djangorestframework==3.8.2
 flake8==3.5.0
 Markdown==2.6.11
 progressbar2==3.34.3


### PR DESCRIPTION
This PR aims to factorize and modularize permission classes, as explained in #74.

So far, those tasks were completed:

* [x] Use atomic permission classes and compose them in the view (done with permission classes composition, available in DRF 3.9.0, instead of REST condition plugin as proposed in the issue);
* [ ] ~Test these atomic permission classes~ (these classes are tested in the views code; it seems complicated to test them unitary within their real flow);
* [x] ~Remove some inappropriate permission classes~ (done by #92);
* [x] Refactorize and clean the methods to check user permission outside of permission classes;
* [x] Test these methods.

The PR made some side effects:

* Upgrade Django REST framework to v3.9.1;
* Move pagination class `library.view.LibraryPagination` to `internal.pagination.PageNumberPaginationCustom`;
* Make this pagination class the default for the whole project (due to DRF 3.7);
* Do not use `serializers.CurrentUserDefault()` to add the current user to a serializer, use `serializer.save(owner=self.request.user)` in view instead (due to DRF 3.8).

This PR should have its counterpart in the client as well.