### PR TITLE
Security updates for Django and PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ channels==2.1.5
 coreapi==2.3.3
 dj-database-url==0.5.0
 django-ordered-model==2.0.0
-Django==1.11.18
+Django==1.11.20
 djangorestframework==3.9.1
 flake8==3.5.0
 Markdown==2.6.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ pytest-mock==1.10.0
 pytest==3.6.3
 python-decouple==3.1
 pywin32==223; sys_platform == 'win32'
-PyYAML==3.12
+PyYAML==4.2b4
 tblib==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ channels==2.1.5
 coreapi==2.3.3
 dj-database-url==0.5.0
 django-ordered-model==2.0.0
-Django==1.11.15
+Django==1.11.18
 djangorestframework==3.6.4
 flake8==3.5.0
 Markdown==2.6.11


### PR DESCRIPTION
This PR updates two dependencies of the project that suffer from vulnerabilities:

* Django 1.11.15 to 1.11.20, [CVE-2019-3498](https://nvd.nist.gov/vuln/detail/CVE-2019-3498);
* PyYAML 3.12 to 4.2b4, [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342). The latest version including the patch seems to be a beta version, though.