### PR TITLE
Reset internal player and current playlist entry when the player disconnects

### DIFF
--- a/dakara_server/playlist/consumers.py
+++ b/dakara_server/playlist/consumers.py
@@ -84,6 +84,17 @@ class PlaylistDeviceConsumer(DakaraJsonWebsocketConsumer):
             self.group_name, self.channel_name
         )
 
+        entry = models.PlaylistEntry.get_playing()
+        if entry:
+            # reset the current playing song
+            entry.date_played = None
+            entry.save()
+
+        # set player idle
+        player = models.Player.get_or_create()
+        player.reset()
+        player.save()
+
         # broadcast the player is idle
         broadcast_to_channel("playlist.front", "send_player_idle")
 


### PR DESCRIPTION
This PR aims to fix #97.

On disconnect, the `PlaylistDeviceConsumer` now resets the current playlist entry and resets the player, setting it to idle. It is the only time where the consumer directly affects the player object (which is normally updated by regular HTTP routes). This is justified by the fact that the player cannot communicate anymore after being disconnected.