### PR TITLE
Fix crash with 2 works with same title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Crash when 2 works exists with same title but different subtitle.
+
 ## 1.5.0 - 2019-12-05
 
 ### Added

--- a/dakara_server/library/serializers.py
+++ b/dakara_server/library/serializers.py
@@ -218,7 +218,11 @@ class SongSerializer(serializers.ModelSerializer):
             )
 
             # create work
-            work, _ = Work.objects.get_or_create(**work_data, work_type=work_type)
+            work, _ = Work.objects.get_or_create(
+                title=work_data["title"],
+                subtitle=work_data.get("subtitle", ""),
+                work_type=work_type,
+            )
 
             # create work link
             SongWorkLink.objects.create(**songworklink_data, song=song, work=work)


### PR DESCRIPTION
If a third work with no subtitle was created as en embeded object, the
get or create would try to find an existing work with same title,
disregarding subtitle. This could cause wrong work link or crash.