### PR TITLE
Fix `send_to_channel` too strict

### DIFF
--- a/dakara_server/playlist/consumers.py
+++ b/dakara_server/playlist/consumers.py
@@ -43,6 +43,10 @@ def send_to_channel(name, event_type, data=None):
         event_type (str): type of the event.
         data (dict): data to pass to the method.
     """
+    # if the channel does not exist, do nothing
+    if name is None:
+        return
+
     # get channel name
     if name == PlaylistDeviceConsumer.name:
         channel_name = PlaylistDeviceConsumer.get_channel_name()

--- a/dakara_server/playlist/tests/test_consumers.py
+++ b/dakara_server/playlist/tests/test_consumers.py
@@ -59,7 +59,16 @@ class TestSendToChannel:
             "channel name", {"type": "type", "key": "value"}
         )
 
-    def test_send_unknown(self, mocker):
+    def test_send_to_none(self, mocker):
+        """Test to send an event to no consumer
+        """
+        mocked_async_to_sync = mocker.patch("playlist.consumers.async_to_sync")
+
+        consumers.send_to_channel(None, "type", {"key": "value"})
+
+        mocked_async_to_sync.assert_not_called()
+
+    def test_send_to_unknown(self, mocker):
         """Test to send an event to unknown consumer
         """
         mocked_async_to_sync = mocker.patch("playlist.consumers.async_to_sync")


### PR DESCRIPTION
When a view needs to send something to a channel, the channel may not exist at this time. We have to ignore the message that was supposed to be sent in that case.

This PR aims to make `send_to_channel` more permissive by ignoring messages sent to `None`.