### PR TITLE
Exclude versions of cryptography without wheels for Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ PyYAML==4.2b4
 Pygments<2.6.0,>=2.5.0
 black==19.10b0; python_version >= '3.6'
 channels<2.5.0,>=2.4.0
+cryptography!=3.3,!=3.3.1
 codecov
 coreapi<2.4.0,>=2.3.3
 coverage


### PR DESCRIPTION
[Cryptography](https://pypi.org/project/cryptography/) version [3.3.1](https://pypi.org/project/cryptography/3.3.1/#files) and [3.3](https://pypi.org/project/cryptography/3.3/#files) at least do not have wheels for Windows. These versions cannot be built on Appveyor, and probably not on a regular Windows box (at least without user intervention). This PR excludes the two aforementioned versions from dependencies.