### PR TITLE
Fix the cryptography package problem on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ init:
 # command to install system and python dependencies
 install:
   # upgrade pip
-  - "py -%PYTHON% -m pip install --upgrade pip"
+  - "py -%PYTHON_VERSION% -m pip install --upgrade pip"
 
   # install dependencies for test
   - "py -%PYTHON_VERSION% -m pip install -r requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,6 +41,9 @@ init:
 
 # command to install system and python dependencies
 install:
+  # upgrade pip
+  - "py -%PYTHON% -m pip install --upgrade pip"
+
   # install dependencies for test
   - "py -%PYTHON_VERSION% -m pip install -r requirements.txt"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ branches:
 
 # command to install python dependencies
 install:
+  # upgrade pip
+  - python -m pip install --upgrade pip
+
   # manually install a recent version of attrs as it is missing from Travis
   - python -m pip install --upgrade "attrs>=19.3.0"
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ It is strongly recommended to run the Dakara server in a virtual environment.
 
 #### Python dependencies
 
+Having a recent enough versio of `pip` is required to install some dependencies properly:
+
+```sh
+pip install --upgrade pip
+```
+
 Install dependencies, at the root level of the repo (in the virtual environment):
 
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ PyYAML==4.2b4
 Pygments<2.6.0,>=2.5.0
 black==19.10b0; python_version >= '3.6'
 channels<2.5.0,>=2.4.0
-cryptography!=3.3,!=3.3.1
 codecov
 coreapi<2.4.0,>=2.3.3
 coverage


### PR DESCRIPTION
The cryptography module has changed and newer versions starting 3.3 seem to not provide wheels for [other than Python 3.6](https://pypi.org/project/cryptography/3.4.6/#files), where older versions supported [far more versions](https://pypi.org/project/cryptography/3.2.1/#files). On Windows, despite a wheel being present for 3.6, the module had to be compiled from source, which failed on the CI, and most presumably on any end-user system (because of missing headers on 3.3, then because of missing Rust compiler on 3.4). The solution used in deca450bd000f74f11dba8fe7d4ffe8ef03cda55 was to blacklist the versions of cryptography without the corresponding wheels, thinking it was a packaging mistake from the developers. However, new versions of the module proved this was not the case.

As blacklisting every version of the module wasn't feasible, neither a proper solution, another approach was necessary. The [changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07) states that a change in wheels format requires to upgrade `pip`. This seems to solve the problem, even on Windows. What is peculiar however, is that the wheels for CPython 3.6 are used on 3.6, 3.7 and 3.8 for both OSes.

This PR ensures that `pip` is up to date on CI, and recommends the end-user to do so.