### PR TITLE
setup ruff as a flake8 replacement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Run style checks
         run: python -m black . --check
 
-      - name: Run PEP8 style checks
-        run: python -m flake8
+      - name: Run ruff linter
+        run: python -m ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
         entry: black . --check
         language: system
         pass_filenames: false
-      - id: flake8-check
-        name: Check PEP8
-        entry: flake8
+      - id: ruff-check
+        name: Run ruff linter
+        entry: ruff check .
         language: system
         pass_filenames: false

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,5 @@
+line-length = 88
+ignore = []
+
+[lint]
+select = ["E", "F", "W", "B"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 line-length = 88
-ignore = []
 
 [lint]
 select = ["E", "F", "W", "B"]
+ignore = []

--- a/dakara_server/internal/cache_model.py
+++ b/dakara_server/internal/cache_model.py
@@ -50,7 +50,7 @@ class CacheManager:
             )
             def handle(sender, **kwargs):
                 instance = kwargs.get("instance")
-                field.on_delete(instance, self)
+                field.cache_on_delete(instance, self)
 
             return handle
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,4 @@ pytest-cov>=4.0.0,<4.1.0
 pytest-django>=4.5.2,<4.6.0
 pytest-mock>=3.10.0,<3.11.0
 pytest>=7.2.0,<7.3.0
-ruff
+ruff>=0.3.0,<0.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,4 @@ pytest-cov>=4.0.0,<4.1.0
 pytest-django>=4.5.2,<4.6.0
 pytest-mock>=3.10.0,<3.11.0
 pytest>=7.2.0,<7.3.0
+ruff

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[flake8]
-max-line-length = 88
-ignore = E203, W503
-
 [coverage:run]
 omit = */tests/*, */conftest.py
 


### PR DESCRIPTION
ruff runs pretty fast, which is nice when used as a pre-commit hook.

It also implements more checks that can be selected as needed, in this
PR I add the bugbear (B) checks which were not present in the
previous configuration and fix issues detected by it.